### PR TITLE
Set `url` in Jekyll config, for RSS readers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ email: ""
 description: >- # this means to ignore newlines until "baseurl:"
   Programming, math, and other things gratuitously nerdy
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://blog.polybdenum.com" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: ""
 github_username:  storyyeller
 


### PR DESCRIPTION
Setting this field instructs Jekyll how to craft the absolute link to a post when generating the feed.xml file for RSS readers. Without this setting, the generated URL looks like `/2025/02/14/designing-type-inference-for-high-quality-type-errors.html` instead of

https://blog.polybdenum.com/2025/02/14/designing-type-inference-for-high-quality-type-errors.html